### PR TITLE
Não quebrar o texto dos links dos menus

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -424,6 +424,7 @@ Full-Width Styles
 }
 
 a.main_menu_link{
+	white-space: nowrap;
 	text-align:center;
 	font-size:17px !important;
 	color:white !important;


### PR DESCRIPTION
em class="main_menu_link"  acrescentei um white-space: nowrap; pra não quebrar o texto do link.

Não fica uma oitava maravilha, mas não é tão estranho quanto estava antes.

antes: http://i.imgur.com/bIW5sfA.png
depois: http://i.imgur.com/yHW4wov.png
